### PR TITLE
64-bit fix

### DIFF
--- a/include/mui/NListtree_mcc.h
+++ b/include/mui/NListtree_mcc.h
@@ -92,11 +92,11 @@ extern "C" {
 
 /*** Special attribute values ***/
 
-#define MUIV_NListtree_Active_Off                           0
-#define MUIV_NListtree_Active_Parent                        -2
-#define MUIV_NListtree_Active_First                         -3
-#define MUIV_NListtree_Active_FirstVisible                  -4
-#define MUIV_NListtree_Active_LastVisible                   -5
+#define MUIV_NListtree_Active_Off                           ((IPTR)0)
+#define MUIV_NListtree_Active_Parent                        ((IPTR)-2)
+#define MUIV_NListtree_Active_First                         ((IPTR)-3)
+#define MUIV_NListtree_Active_FirstVisible                  ((IPTR)-4)
+#define MUIV_NListtree_Active_LastVisible                   ((IPTR)-5)
 
 #define MUIV_NListtree_ActiveList_Off                       0
 
@@ -105,20 +105,20 @@ extern "C" {
 #define MUIV_NListtree_AutoVisible_FirstOpen                2
 #define MUIV_NListtree_AutoVisible_Expand                   3
 
-#define MUIV_NListtree_CompareHook_Head                     0
-#define MUIV_NListtree_CompareHook_Tail                     -1
-#define MUIV_NListtree_CompareHook_LeavesTop                -2
-#define MUIV_NListtree_CompareHook_LeavesMixed              -3
-#define MUIV_NListtree_CompareHook_LeavesBottom             -4
+#define MUIV_NListtree_CompareHook_Head                     ((IPTR)0)
+#define MUIV_NListtree_CompareHook_Tail                     ((IPTR)-1)
+#define MUIV_NListtree_CompareHook_LeavesTop                ((IPTR)-2)
+#define MUIV_NListtree_CompareHook_LeavesMixed              ((IPTR)-3)
+#define MUIV_NListtree_CompareHook_LeavesBottom             ((IPTR)-4)
 
-#define MUIV_NListtree_ConstructHook_String                 -1
+#define MUIV_NListtree_ConstructHook_String                 ((IPTR)-1)
 #define MUIV_NListtree_ConstructHook_Flag_AutoCreate        (1<<15)
 
-#define MUIV_NListtree_CopyToClipHook_Default               0
+#define MUIV_NListtree_CopyToClipHook_Default               ((IPTR)0)
 
-#define MUIV_NListtree_DestructHook_String                  -1
+#define MUIV_NListtree_DestructHook_String                  ((IPTR)-1)
 
-#define MUIV_NListtree_DisplayHook_Default                  -1
+#define MUIV_NListtree_DisplayHook_Default                  ((IPTR)-1)
 
 #define MUIV_NListtree_DoubleClick_Off                      -1
 #define MUIV_NListtree_DoubleClick_All                      -2
@@ -131,17 +131,17 @@ extern "C" {
 #define MUIV_NListtree_DropType_Onto                        3
 #define MUIV_NListtree_DropType_Sorted                      4
 
-#define MUIV_NListtree_FindNameHook_CaseSensitive           0
-#define MUIV_NListtree_FindNameHook_CaseInsensitive         -1
-#define MUIV_NListtree_FindNameHook_Part                    -2
-#define MUIV_NListtree_FindNameHook_PartCaseInsensitive     -3
-#define MUIV_NListtree_FindNameHook_PointerCompare          -4
+#define MUIV_NListtree_FindNameHook_CaseSensitive           ((IPTR)0)
+#define MUIV_NListtree_FindNameHook_CaseInsensitive         ((IPTR)-1)
+#define MUIV_NListtree_FindNameHook_Part                    ((IPTR)-2)
+#define MUIV_NListtree_FindNameHook_PartCaseInsensitive     ((IPTR)-3)
+#define MUIV_NListtree_FindNameHook_PointerCompare          ((IPTR)-4)
 
-#define MUIV_NListtree_FindUserDataHook_CaseSensitive       0
-#define MUIV_NListtree_FindUserDataHook_CaseInsensitive     -1
-#define MUIV_NListtree_FindUserDataHook_Part                -2
-#define MUIV_NListtree_FindUserDataHook_PartCaseInsensitive -3
-#define MUIV_NListtree_FindUserDataHook_PointerCompare      -4
+#define MUIV_NListtree_FindUserDataHook_CaseSensitive       ((IPTR)0)
+#define MUIV_NListtree_FindUserDataHook_CaseInsensitive     ((IPTR)-1)
+#define MUIV_NListtree_FindUserDataHook_Part                ((IPTR)-2)
+#define MUIV_NListtree_FindUserDataHook_PartCaseInsensitive ((IPTR)-3)
+#define MUIV_NListtree_FindUserDataHook_PointerCompare      ((IPTR)-4)
 
 #define MUIV_NListtree_MultiSelect_None                     0
 #define MUIV_NListtree_MultiSelect_Default                  1
@@ -149,7 +149,7 @@ extern "C" {
 #define MUIV_NListtree_MultiSelect_Always                   3
 
 
-#define MUIV_NListtree_ShowTree_Toggle                      -1
+#define MUIV_NListtree_ShowTree_Toggle                      ((IPTR)-1)
 
 
 /*** Structures & Flags ***/

--- a/nlisttree_mcc/NListtree.c
+++ b/nlisttree_mcc/NListtree.c
@@ -4349,10 +4349,10 @@ static VOID SetAttributes( struct NListtree_Data *data, struct opSet *msg, BOOL 
       case MUIA_NListtree_Active:
       {
         D(DBF_GETSET, "SET MUIA_NListtree_Active");
-        if((tag->ti_Data == (ULONG)MUIV_NListtree_Active_Off) ||
+        if((tag->ti_Data == (IPTR)MUIV_NListtree_Active_Off) ||
            (tag->ti_Data == (IPTR)&data->RootList) ||
-           ((tag->ti_Data == (ULONG)MUIV_NListtree_Active_Parent) &&
-            (data->ActiveNode == (ULONG)MUIV_NListtree_Active_Off))
+           ((tag->ti_Data == (IPTR)MUIV_NListtree_Active_Parent) &&
+            (data->ActiveNode == (APTR)MUIV_NListtree_Active_Off))
           )
         {
           actnode = MUIV_NListtree_Active_Off;
@@ -4365,7 +4365,7 @@ static VOID SetAttributes( struct NListtree_Data *data, struct opSet *msg, BOOL 
           /*
           **  Parent of the active node.
           */
-          if(tag->ti_Data == (ULONG)MUIV_NListtree_Active_Parent)
+          if(tag->ti_Data == (IPTR)MUIV_NListtree_Active_Parent)
           {
             tag->ti_Data = (IPTR)GetParent( data->ActiveNode );
           }
@@ -4373,13 +4373,13 @@ static VOID SetAttributes( struct NListtree_Data *data, struct opSet *msg, BOOL 
           /*
           **  First list entry (visible or not).
           */
-          if(tag->ti_Data == (ULONG)MUIV_NListtree_Active_First)
+          if(tag->ti_Data == (IPTR)MUIV_NListtree_Active_First)
             tag->ti_Data = (IPTR)GetHead( (struct List *)&data->RootList.ln_List );
 
           /*
           **  First visible entry.
           */
-          if(tag->ti_Data == (ULONG)MUIV_NListtree_Active_FirstVisible)
+          if(tag->ti_Data == (IPTR)MUIV_NListtree_Active_FirstVisible)
           {
             LONG firstvisible;
 
@@ -4392,7 +4392,7 @@ static VOID SetAttributes( struct NListtree_Data *data, struct opSet *msg, BOOL 
           /*
           **  Last visible entry.
           */
-          if(tag->ti_Data == (ULONG)MUIV_NListtree_Active_LastVisible)
+          if(tag->ti_Data == (IPTR)MUIV_NListtree_Active_LastVisible)
           {
             LONG lastvisible;
 
@@ -4621,7 +4621,7 @@ static VOID SetAttributes( struct NListtree_Data *data, struct opSet *msg, BOOL 
 
       case MUIA_NListtree_CopyToClipHook:
       {
-        if ( tag->ti_Data == MUIV_NListtree_CopyToClipHook_Default )
+        if ( tag->ti_Data == (IPTR)MUIV_NListtree_CopyToClipHook_Default )
         {
           D(DBF_GETSET, "SET MUIA_NListtree_CopyToClipHook: MUIV_NListtree_CopyToClipHook_Default");
 
@@ -4934,7 +4934,7 @@ static VOID SetAttributes( struct NListtree_Data *data, struct opSet *msg, BOOL 
 
       case MUIA_NListtree_ShowTree:
       {
-        if(tag->ti_Data == (ULONG)MUIV_NListtree_ShowTree_Toggle)
+        if(tag->ti_Data == (IPTR)MUIV_NListtree_ShowTree_Toggle)
         {
           if(isFlagSet(data->Flags, NLTF_NO_TREE))
             CLEAR_FLAG(data->Flags, NLTF_NO_TREE);

--- a/nlisttree_mcc/private.h
+++ b/nlisttree_mcc/private.h
@@ -123,11 +123,11 @@
 
 /*** Special attribute values ***/
 
-#define MUIV_NListtree_Active_Off                           0
-#define MUIV_NListtree_Active_Parent                        -2
-#define MUIV_NListtree_Active_First                         -3
-#define MUIV_NListtree_Active_FirstVisible                  -4
-#define MUIV_NListtree_Active_LastVisible                   -5
+#define MUIV_NListtree_Active_Off                           ((IPTR)0)
+#define MUIV_NListtree_Active_Parent                        ((IPTR)-2)
+#define MUIV_NListtree_Active_First                         ((IPTR)-3)
+#define MUIV_NListtree_Active_FirstVisible                  ((IPTR)-4)
+#define MUIV_NListtree_Active_LastVisible                   ((IPTR)-5)
 
 #define MUIV_NListtree_ActiveList_Off                       0
 
@@ -136,20 +136,20 @@
 #define MUIV_NListtree_AutoVisible_FirstOpen                2
 #define MUIV_NListtree_AutoVisible_Expand                   3
 
-#define MUIV_NListtree_CompareHook_Head                     0
-#define MUIV_NListtree_CompareHook_Tail                     -1
-#define MUIV_NListtree_CompareHook_LeavesTop                -2
-#define MUIV_NListtree_CompareHook_LeavesMixed              -3
-#define MUIV_NListtree_CompareHook_LeavesBottom             -4
+#define MUIV_NListtree_CompareHook_Head                     ((IPTR)0)
+#define MUIV_NListtree_CompareHook_Tail                     ((IPTR)-1)
+#define MUIV_NListtree_CompareHook_LeavesTop                ((IPTR)-2)
+#define MUIV_NListtree_CompareHook_LeavesMixed              ((IPTR)-3)
+#define MUIV_NListtree_CompareHook_LeavesBottom             ((IPTR)-4)
 
-#define MUIV_NListtree_ConstructHook_String                 -1
+#define MUIV_NListtree_ConstructHook_String                 ((IPTR)-1)
 #define MUIV_NListtree_ConstructHook_Flag_AutoCreate        (1<<15)
 
-#define MUIV_NListtree_CopyToClipHook_Default               0
+#define MUIV_NListtree_CopyToClipHook_Default               ((IPTR)0)
 
-#define MUIV_NListtree_DestructHook_String                  -1
+#define MUIV_NListtree_DestructHook_String                  ((IPTR)-1)
 
-#define MUIV_NListtree_DisplayHook_Default                  -1
+#define MUIV_NListtree_DisplayHook_Default                  ((IPTR)-1)
 
 #define MUIV_NListtree_DoubleClick_Off                      -1
 #define MUIV_NListtree_DoubleClick_All                      -2
@@ -162,18 +162,18 @@
 #define MUIV_NListtree_DropType_Onto                        3
 #define MUIV_NListtree_DropType_Sorted                      4
 
-#define MUIV_NListtree_FindNameHook_CaseSensitive           0
-#define MUIV_NListtree_FindNameHook_CaseInsensitive         -1
-#define MUIV_NListtree_FindNameHook_PartCaseSensitive       -2
-#define MUIV_NListtree_FindNameHook_PartCaseInsensitive     -3
-#define MUIV_NListtree_FindNameHook_PointerCompare          -4
+#define MUIV_NListtree_FindNameHook_CaseSensitive           ((IPTR)0)
+#define MUIV_NListtree_FindNameHook_CaseInsensitive         ((IPTR)-1)
+#define MUIV_NListtree_FindNameHook_PartCaseSensitive       ((IPTR)-2)
+#define MUIV_NListtree_FindNameHook_PartCaseInsensitive     ((IPTR)-3)
+#define MUIV_NListtree_FindNameHook_PointerCompare          ((IPTR)-4)
 #define MUIV_NListtree_FindNameHook_Part                    MUIV_NListtree_FindNameHook_PartCaseSensitive /* obsolete */
 
-#define MUIV_NListtree_FindUserDataHook_CaseSensitive       0
-#define MUIV_NListtree_FindUserDataHook_CaseInsensitive     -1
-#define MUIV_NListtree_FindUserDataHook_Part                -2
-#define MUIV_NListtree_FindUserDataHook_PartCaseInsensitive -3
-#define MUIV_NListtree_FindUserDataHook_PointerCompare      -4
+#define MUIV_NListtree_FindUserDataHook_CaseSensitive       ((IPTR)0)
+#define MUIV_NListtree_FindUserDataHook_CaseInsensitive     ((IPTR)-1)
+#define MUIV_NListtree_FindUserDataHook_Part                ((IPTR)-2)
+#define MUIV_NListtree_FindUserDataHook_PartCaseInsensitive ((IPTR)-3)
+#define MUIV_NListtree_FindUserDataHook_PointerCompare      ((IPTR)-4)
 
 #define MUIV_NListtree_MultiSelect_None                     0
 #define MUIV_NListtree_MultiSelect_Default                  1
@@ -182,7 +182,7 @@
 
 #define MUIV_NListtree_MultiSelect_Flag_AutoSelectChilds    (1<<31) /*i*/
 
-#define MUIV_NListtree_ShowTree_Toggle                      -1
+#define MUIV_NListtree_ShowTree_Toggle                      ((IPTR)-1)
 
 
 


### PR DESCRIPTION
Literals are treated as int (32-bit) by default. This causes wrong 64-bit
values for negative numbers. Extend the literals to size of long depending
on platform.